### PR TITLE
do not pass Item around

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>job-dsl</artifactId>
-      <version>1.46</version>
+      <version>1.47</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/ConditionsContext.java
+++ b/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/ConditionsContext.java
@@ -51,8 +51,8 @@ public class ConditionsContext extends AbstractExtensibleContext {
 
 	final List<Node> conditionNodes = new ArrayList<>();
 
-	public ConditionsContext(JobManagement jobManagement, Item item, DslEnvironment dslEnvironment) {
-		super(jobManagement, item);
+	public ConditionsContext(JobManagement jobManagement, DslEnvironment dslEnvironment) {
+		super(jobManagement, null);
 		this.dslEnvironment = dslEnvironment;
 		this.metaClass = InvokerHelper.getMetaClass(this.getClass());
 	}

--- a/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionContext.java
+++ b/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionContext.java
@@ -29,8 +29,6 @@ class PromotionContext extends Item {
     // never persist the MetaClass
     private transient MetaClass metaClass;
 
-    /** the owning project */
-    protected final Item parentItem;
     protected final DslEnvironment dslEnvironment;
 
     private List<Node> actions = new ArrayList<Node>();
@@ -76,10 +74,9 @@ class PromotionContext extends Item {
         }, "call"));
     }
 
-    public PromotionContext(JobManagement jobManagement, Item item, DslEnvironment dslEnvironment) {
+    public PromotionContext(JobManagement jobManagement, DslEnvironment dslEnvironment) {
         super(jobManagement);
         this.metaClass = InvokerHelper.getMetaClass(this.getClass());
-        this.parentItem = item;
         this.dslEnvironment = dslEnvironment;
     }
 
@@ -88,7 +85,7 @@ class PromotionContext extends Item {
      */
     public void conditions(@DslContext(ConditionsContext.class) Closure<?> conditionClosure) {
         // delegate to ConditionsContext
-        final ConditionsContext conditionContext = new ConditionsContext(jobManagement, parentItem, dslEnvironment);
+        final ConditionsContext conditionContext = new ConditionsContext(jobManagement, dslEnvironment);
         executeInContext(conditionClosure, conditionContext);
         configure(new MethodClosure(new Object() {
             @SuppressFBWarnings(value = "UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS", justification = "Dynamically called by MethodClosure")

--- a/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionsContext.java
+++ b/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionsContext.java
@@ -14,14 +14,12 @@ import groovy.lang.Closure;
 import static javaposse.jobdsl.plugin.ContextExtensionPoint.executeInContext;
 
 public class PromotionsContext extends AbstractContext {
-    protected final Item item;
     protected final DslEnvironment dslEnvironment;
 
     protected List<PromotionContext> promotionContexts = new ArrayList<PromotionContext>();
 
-    public PromotionsContext(JobManagement jobManagement, Item item, DslEnvironment dslEnvironment) {
+    public PromotionsContext(JobManagement jobManagement, DslEnvironment dslEnvironment) {
         super(jobManagement);
-        this.item = item;
         this.dslEnvironment = dslEnvironment;
     }
 
@@ -30,7 +28,7 @@ public class PromotionsContext extends AbstractContext {
     }
 
     public void promotion(String name, @DslContext(PromotionContext.class) Closure promotionClosure) {
-        PromotionContext promotionContext = new PromotionContext(jobManagement, item, dslEnvironment);
+        PromotionContext promotionContext = new PromotionContext(jobManagement, dslEnvironment);
         promotionContext.setName(name);
         executeInContext(promotionClosure, promotionContext);
         Preconditions.checkNotNull(promotionContext.getName(), "promotion name cannot be null");

--- a/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionsExtensionPoint.java
+++ b/src/main/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionsExtensionPoint.java
@@ -70,18 +70,16 @@ public class PromotionsExtensionPoint extends ContextExtensionPoint {
      */
     public static class FakeContext implements Context {
         private final JobManagement jobManagement;
-        private final javaposse.jobdsl.dsl.Item item;
 
-        public FakeContext(JobManagement jobManagement, javaposse.jobdsl.dsl.Item item) {
+        public FakeContext(JobManagement jobManagement) {
             this.jobManagement = jobManagement;
-            this.item = item;
         }
     }
 
     @DslExtensionMethod(context = PropertiesContext.class)
     public Object promotions(Runnable closure, DslEnvironment dslEnvironment) throws FormException, IOException {
         FakeContext fakeContext = dslEnvironment.createContext(FakeContext.class);
-        PromotionsContext context = new PromotionsContext(fakeContext.jobManagement, fakeContext.item, dslEnvironment);
+        PromotionsContext context = new PromotionsContext(fakeContext.jobManagement, dslEnvironment);
 
         executeInContext(closure, context);
 

--- a/src/test/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionContextTest.java
+++ b/src/test/java/hudson/plugins/promoted_builds/integrations/jobdsl/PromotionContextTest.java
@@ -38,7 +38,7 @@ public class PromotionContextTest {
     @Test
     public void shouldGenerateValidXml() throws Exception {
 
-        final PromotionContext promotionContext = new PromotionContext(jobManagement, item, new DslEnvironmentImpl(jobManagement, item));
+        final PromotionContext promotionContext = new PromotionContext(jobManagement, new DslEnvironmentImpl(jobManagement, item));
 
         final Object thisObject = new Object();
         final Object owner = new Object();


### PR DESCRIPTION
since Job DSL 1.47 the item is not needed for extensible contexts that do not create items
